### PR TITLE
Comment out baseUrl so autocomplete imports use correct relative path

### DIFF
--- a/templates/jet/tsconfig.json
+++ b/templates/jet/tsconfig.json
@@ -37,7 +37,7 @@
 
     /* Module Resolution Options */
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
+    // "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
     // "paths": { "@/*": ["./app/*"] },       /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. See: https://www.typescriptlang.org/tsconfig#paths */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */


### PR DESCRIPTION
Autocomplete imports on jet were not using relative paths. Commenting out baseUrl in the `tsconfig`, fixes the issue and now matches blimp.