### PR TITLE
Update the root build.gradle for blimp and jet

### DIFF
--- a/templates/blimp/android/build.gradle
+++ b/templates/blimp/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
     }
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.3")
+        classpath("com.android.tools.build:gradle:4.0.1")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -32,6 +32,7 @@ allprojects {
 
         google()
         jcenter()
+        maven { url 'https://maven.google.com' }
         maven { url 'https://www.jitpack.io' }
     }
 }

--- a/templates/jet/android/build.gradle
+++ b/templates/jet/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
     }
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.3")
+        classpath("com.android.tools.build:gradle:4.0.1")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -32,6 +32,7 @@ allprojects {
 
         google()
         jcenter()
+        maven { url 'https://maven.google.com' }
         maven { url 'https://www.jitpack.io' }
     }
 }


### PR DESCRIPTION
While building in App Center, Android failed with the following:
https://cargo.teamairship.com/qJgPgV

This PR fixes this issue by adding google in maven. Also, upgrading the version of gradle used and increasing the `minSdkVersion` since App Center does not support anything under version `21`.

Tested with a successful build, install, and running of the app in my current project.
https://cargo.teamairship.com/zDFFdo