### PR TITLE
Add missing apply statement for react-native-config for android

### DIFF
--- a/templates/blimp/android/app/build.gradle
+++ b/templates/blimp/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 import com.android.build.OutputFile
 

--- a/templates/jet/android/app/build.gradle
+++ b/templates/jet/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 import com.android.build.OutputFile
 


### PR DESCRIPTION
Add missing apply statement for react-native-config in blimp and jet for android to correctly use the library. Without this, I was not able to have variables pulled in correctly using the package. Tested and working in the current project I am working on.

https://github.com/luggit/react-native-config#extra-step-for-android