### PR TITLE
Amy/add resolver workaround to metro config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,7 @@ Make sure all tests are passing.
 ## Issues
 
 All feature requests, bug reports, questions, etc. welcome! [Please submit issues here](https://github.com/teamairship/airfoil-schematics/issues).
+
+## Updates and Fixes
+
+- Added resolver as a workaround by configuring Metro to understand the .cjs file extension until [this issue](https://github.com/facebook/metro/issues/535) is resolved. Solution found in Apollo Client 3.5.4 release notices [here](https://github.com/apollographql/apollo-client/releases)

--- a/templates/jet/metro.config.js
+++ b/templates/jet/metro.config.js
@@ -5,6 +5,9 @@
  * @format
  */
 
+const { getDefaultConfig } = require('metro-config');
+const { resolver: defaultResolver } = getDefaultConfig.getDefaultValues();
+
 module.exports = {
   transformer: {
     getTransformOptions: async () => ({
@@ -13,5 +16,9 @@ module.exports = {
         inlineRequires: true,
       },
     }),
+  },
+  resolver: {
+    ...defaultResolver,
+    sourceExts: [...defaultResolver.sourceExts, 'cjs'],
   },
 };

--- a/templates/jet/metro.config.js
+++ b/templates/jet/metro.config.js
@@ -3,6 +3,11 @@
  * https://github.com/facebook/react-native
  *
  * @format
+ *
+ * Added resolver as a workaround by configuring Metro to understand the .cjs file extension until the following issue is resolved:
+ * https://github.com/facebook/metro/issues/535
+ * Solution found in Apollo Client 3.5.4 release notices here:
+ * https://github.com/apollographql/apollo-client/releases
  */
 
 const { getDefaultConfig } = require('metro-config');


### PR DESCRIPTION
Add resolver workaround to metro config

Because:
- When creating a new project and running it we are getting an error on startup

This commit:
- Adds resolver as a workaround by configuring Metro to understand the .cjs file extension until [this issue](https://github.com/facebook/metro/issues/535) is resolved. Solution found in Apollo Client 3.5.4 release notices [here](https://github.com/apollographql/apollo-client/releases).
